### PR TITLE
Fix compilation mistakes that old versions of GCC allowed

### DIFF
--- a/wmsystray/Makefile
+++ b/wmsystray/Makefile
@@ -1,7 +1,7 @@
 include ../Rules.make
 
 CC = gcc
-CFLAGS = ${X11CFLAGS} -DTRACE_LEVEL=${TRACE_LEVEL} -I../xembed -Wall -g
+CFLAGS = ${X11CFLAGS} -DTRACE_LEVEL=${TRACE_LEVEL} -I../xembed -Wall -g -D_POSIX_C_SOURCE=199309L -D_XOPEN_SOURCE=500
 LDFLAGS = ${X11LDFLAGS} -lXpm
 
 OBJS = main.o ui.o systray.o xpms.o

--- a/wmsystray/systray.c
+++ b/wmsystray/systray.c
@@ -338,7 +338,7 @@ int handle_dock_request (Window embed_wind) {
 		XReparentWindow (main_disp, embed_wind,
 				DefaultRootWindow(main_disp), 0, 0);
 		TRACE((stderr, "REJECTED!\n"));
-		return;
+		return 1;
 	}
 
 	XSelectInput (main_disp, embed_wind, StructureNotifyMask |

--- a/wmsystray/systray.h
+++ b/wmsystray/systray.h
@@ -36,5 +36,7 @@ void cleanup_systray();
 int event_is_systray_event(XEvent *ev);
 int handle_systray_event(XEvent *ev);
 void repaint_systray();
+struct systray_item *find_systray_item (Window id);
+int systray_property_update (struct systray_item *item);
 
 #endif

--- a/wmsystray/ui.c
+++ b/wmsystray/ui.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <signal.h>
+#include <unistd.h>
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -28,7 +29,6 @@ char *geometry_string = "64x64+0+0";
 int width, height, pos_x, pos_y;
 Pixmap bg_pixmap;
 char *bg_data;
-void draw_ui_elements();
 
 int wmaker = 1;
 int loop_program = 1;

--- a/wmsystray/ui.c
+++ b/wmsystray/ui.c
@@ -28,6 +28,7 @@ char *geometry_string = "64x64+0+0";
 int width, height, pos_x, pos_y;
 Pixmap bg_pixmap;
 char *bg_data;
+void draw_ui_elements();
 
 int wmaker = 1;
 int loop_program = 1;

--- a/wmsystray/ui.h
+++ b/wmsystray/ui.h
@@ -24,5 +24,6 @@ extern char *geometry_string;
 extern Display *main_disp;
 extern Window main_wind, icon_wind, sel_wind, draw_wind;
 extern char * wmsystray_xpm[];
+void draw_ui_elements();
 
 #endif

--- a/xembed/xembed.c
+++ b/xembed/xembed.c
@@ -2,6 +2,8 @@
  xembed.c
  ****************************************************************************/
 
+#include <string.h>
+
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include "xembed.h"


### PR DESCRIPTION
Now, we live in a future of C99, where explicit function declarations are mandatory, as are returns values.

There are still warnings, but with this program complies with -std=c11 and -std=c23